### PR TITLE
Fixed recursive flag always `false`

### DIFF
--- a/src/main/java/io/slingr/endpoints/ftp/FtpEndpoint.java
+++ b/src/main/java/io/slingr/endpoints/ftp/FtpEndpoint.java
@@ -53,7 +53,7 @@ public class FtpEndpoint extends Endpoint {
     private String outputFolder;
 
     @EndpointProperty(name = "recursive")
-    private Boolean recursive;
+    private String recursive;
 
     private Processor processor = null;
 

--- a/src/main/java/io/slingr/endpoints/ftp/beans/Processor.java
+++ b/src/main/java/io/slingr/endpoints/ftp/beans/Processor.java
@@ -55,7 +55,7 @@ public class Processor extends RouteBuilder {
 
     public Processor(AppLogs appLogs, Events events, Files files, String name, boolean localDeployment,
                      String protocol, String host, String port, String username, String password, String filePattern,
-                     String inputFolder, String archiveFolder, String archiveGrouping, Boolean recursive, String outputFolder
+                     String inputFolder, String archiveFolder, String archiveGrouping, String recursive, String outputFolder
     ) {
         this.appLogs = appLogs;
         this.events = events;
@@ -99,7 +99,7 @@ public class Processor extends RouteBuilder {
             }
         }
 
-        this.recursive = Boolean.TRUE.equals(recursive);
+        this.recursive = recursive.equals("enabled");
         if(this.recursive){
             if(folder1.startsWith(folder2)){
                 throw new IllegalArgumentException(


### PR DESCRIPTION
We are working with the FTP Endpoint and we didn't receive any `newFile` event when uploading files to a subdirectory from the input folder.

We ran the endpoint locally and we find out that there is a mismatch on the types. The input `recursive` is an string value and the processor class constructor was expecting a boolean type.

We fixed so it can receive the string and make the conversion afterwards.
